### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Wk4021/Discord-Reputation-Bot/security/code-scanning/1](https://github.com/Wk4021/Discord-Reputation-Bot/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Since the workflow only installs dependencies, runs tests, and performs linting, it does not require write access to the repository or other resources. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
