### PR TITLE
Add auto-close system and interactive settings (V3.1)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,305 @@
+# 📋 Discord Reputation Bot V3.1 - Command Reference
+
+Complete documentation for all slash commands and interactive features in Discord Reputation Bot V3.1.
+
+---
+
+## 🆕 **New in V3.1**
+
+### **Interactive Settings Management**
+- **`/settings`**: Comprehensive dashboard with buttons and modal forms
+- **Auto-Close Controls**: Toggle and configure automatic thread closure
+- **User Notifications**: Mentions when users receive reviews
+- **Enhanced Logging**: All actions logged to console and Discord
+
+---
+
+## 📊 **Public Commands**
+
+### `/reviews <user>`
+**Description**: View a user's review statistics and recent reviews  
+**Usage**: `/reviews @username`  
+**Permissions**: Everyone  
+**Example Output**:
+```
+⭐ Reviews for Username
+Rating: ⭐⭐⭐⭐✨ (8.5/10 from 12 reviews)
+
+📝 Latest Reviews
+⭐⭐⭐⭐⭐ 10/10 by @reviewer1
+> Excellent seller, fast delivery!
+
+⭐⭐⭐⭐☆ 8/10 by @reviewer2  
+> Good communication, item as described
+```
+
+### `/leaderboard`
+**Description**: Show the top 10 highest rated users  
+**Usage**: `/leaderboard`  
+**Permissions**: Everyone  
+**Example Output**:
+```
+🏆 Top Rated Users
+
+1. Username1 - ⭐⭐⭐⭐⭐ 9.8/10 (25 reviews)
+2. Username2 - ⭐⭐⭐⭐✨ 9.2/10 (18 reviews)
+3. Username3 - ⭐⭐⭐⭐☆ 8.9/10 (31 reviews)
+...
+```
+
+---
+
+## 👑 **Admin Commands**
+
+### `/settings` *(NEW in V3.1)*
+**Description**: Interactive settings dashboard with buttons and forms  
+**Usage**: `/settings`  
+**Permissions**: Admin only (user ID or role ID)  
+**Features**:
+- **🔧 Auto-Close Settings**: Enable/disable and set timer
+- **📋 TOS Settings**: Edit TOS message and decline response
+- **👑 Admin Settings**: View current admins (read-only)
+- **🌐 Server Settings**: Configure server name and invite link
+- **🔄 Refresh**: Update display with current values
+
+**Dashboard Display**:
+```
+⚙️ Bot Settings Dashboard
+
+🔧 Auto-Close Settings    📁 Forum Channels    📝 Log Channel
+Status: ✅ Enabled        Tracking: 3 forums   Channel: #logs
+Timer: 24 hours
+
+👑 Admin Settings         🌐 Server Info       📋 TOS Settings
+Users: 2                  Name: My Server      Message: Configured
+Roles: 1                                       Decline: Configured
+```
+
+### `/auto_close_toggle [enabled]` *(NEW in V3.1)*
+**Description**: Toggle auto-close feature on/off or view current status  
+**Usage**: 
+- `/auto_close_toggle` - Show current status
+- `/auto_close_toggle true` - Enable auto-close
+- `/auto_close_toggle false` - Disable auto-close
+**Permissions**: Admin only  
+**Example Output**:
+```
+⚙️ Auto-Close Setting Updated
+Auto-close feature is now ✅ Enabled
+
+Timer: Threads will auto-close 24 hours after first review
+```
+
+### `/auto_close_hours <hours>` *(NEW in V3.1)*
+**Description**: Set the number of hours before auto-close (1-168 hours)  
+**Usage**: `/auto_close_hours 48`  
+**Permissions**: Admin only  
+**Validation**: Hours must be between 1 and 168 (1 week maximum)  
+**Example Output**:
+```
+⏰ Auto-Close Timer Updated
+Auto-close timer set to 48 hours
+
+Previous: 24 hours → New: 48 hours
+Note: This only affects new auto-close schedules.
+```
+
+### `/send_review_ui` *(NEW in V3.1)*
+**Description**: Manually send the review interface to current thread  
+**Usage**: `/send_review_ui` (must be used in a thread)  
+**Permissions**: Admin only  
+**Use Case**: When review interface needs to be re-sent or manually triggered  
+**Example**: Useful if the automatic interface was deleted or didn't appear
+
+### `/channel_set <channel>`
+**Description**: Add a forum channel for reputation tracking  
+**Usage**: `/channel_set #marketplace-forum`  
+**Permissions**: Admin only  
+**Effect**: Bot will monitor new threads in this forum and apply TOS gating + review system
+
+### `/log <channel>`
+**Description**: Set the channel where review logs and admin actions are sent  
+**Usage**: `/log #mod-logs`  
+**Permissions**: Admin only  
+**Effect**: All reviews, auto-close events, and admin actions will be logged here
+
+### `/admin_add <user>`
+**Description**: Add a user as admin  
+**Usage**: `/admin_add @username`  
+**Permissions**: Admin only  
+**Effect**: User can use all admin commands and modify settings
+
+### `/admin_remove <user>`
+**Description**: Remove admin privileges from a user  
+**Usage**: `/admin_remove @username`  
+**Permissions**: Admin only  
+**Safety**: Cannot remove yourself if you're the last admin
+
+### `/admin_list`
+**Description**: View all current admins (users and roles)  
+**Usage**: `/admin_list`  
+**Permissions**: Admin only  
+**Example Output**:
+```
+👑 Admin List
+
+Admin Users (2)
+• @Admin1 (Administrator)
+• @Admin2 (Owner)
+
+Admin Roles (1)  
+• @Staff (Staff Role)
+```
+
+### `/admin_role_add <role>` *(NEW in V3.1)*
+**Description**: Add a role that grants admin permissions  
+**Usage**: `/admin_role_add @Staff`  
+**Permissions**: Admin only  
+**Effect**: All users with this role can use admin commands
+
+### `/admin_role_remove <role>` *(NEW in V3.1)*
+**Description**: Remove admin permissions from a role  
+**Usage**: `/admin_role_remove @Staff`  
+**Permissions**: Admin only  
+**Effect**: Users with this role lose admin access (unless they have individual admin status)
+
+---
+
+## 🎮 **Interactive Elements**
+
+### **Review Interface**
+**Triggers**: Appears after TOS acceptance or via `/send_review_ui`  
+**Buttons**:
+- **⭐ Leave a Review**: Opens rating modal (1-10 + optional notes)
+- **Close Post**: Thread owner or admin can close the post
+
+### **Review Modal** *(Enhanced in V3.1)*
+**Fields**:
+- **Rating (1-10)**: Required number input with validation
+- **Review Notes**: Optional text area (500 character limit)
+**Actions After Submission**:
+1. **User gets mentioned**: "@user You received a **8/10** review!"
+2. **First review triggers auto-close**: Warning embed with cancel button appears
+3. **Review logged**: Sent to log channel with full details
+4. **UI refreshes**: Updated rating display with new review
+
+### **Auto-Close Warning** *(NEW in V3.1)*
+**Trigger**: Appears after first review in a thread (if enabled)  
+**Display**:
+```
+⏰ Auto-Close Scheduled
+This thread will automatically close in 24 hours unless you cancel it below.
+
+Why?
+Threads auto-close after the first review to keep the marketplace clean. 
+If you have multiple items in this listing, click the button below.
+
+[I have multiple items - Keep thread open]
+```
+**Button**: Only thread owner can cancel auto-close
+
+---
+
+## 🔧 **Settings Interface Details**
+
+### **Auto-Close Settings Modal**
+**Fields**:
+- **Enable Auto-Close**: `true` or `false`
+- **Auto-Close Hours**: Number between 1-168
+**Validation**: Prevents invalid inputs with error messages
+
+### **TOS Settings Modal**
+**Fields**:
+- **TOS Message**: Multi-line text (1000 char limit) with `{timeout}` placeholder
+- **TOS Decline Response**: Multi-line text (500 char limit)
+**Pre-filled**: Shows current configuration values
+
+### **Server Settings Modal**  
+**Fields**:
+- **Server Display Name**: Text shown on web dashboard (100 char limit)
+- **Server Invite Link**: Optional Discord invite URL (200 char limit)
+**Usage**: Enhances web dashboard branding and functionality
+
+---
+
+## 📝 **Logging & Notifications**
+
+### **Console Logging**
+All major actions are logged to console with timestamps:
+```
+[AUTO-CLOSE] Admin1 enabled auto-close feature
+[AUTO-CLOSE] Scheduled thread 123456789 (Selling iPhone) to close in 24 hours
+[AUTO-CLOSE] User123 cancelled auto-close for thread 123456789
+[AUTO-CLOSE] Successfully closed thread 123456789 (Selling iPhone)
+[SETTINGS] Admin1 accessed settings dashboard
+```
+
+### **Discord Log Channel**
+Comprehensive embeds sent to configured log channel:
+- **Review submissions** with rating and user info
+- **Auto-close scheduling** with thread details and countdown
+- **Auto-close cancellations** with user and reason
+- **Auto-close executions** with thread info and action taken
+- **Settings changes** with before/after values
+- **Admin actions** with user and action details
+
+### **User Notifications** *(NEW in V3.1)*
+Thread owners are mentioned when they receive reviews:
+```
+@ThreadOwner You received a **9/10** review!
+```
+This appears alongside the auto-close warning (if applicable) or as a standalone message.
+
+---
+
+## ⚡ **Quick Reference**
+
+### **Most Used Commands**
+- `/settings` - One-stop shop for all configuration
+- `/reviews @user` - Check someone's reputation
+- `/leaderboard` - See top-rated users
+- `/auto_close_toggle` - Quick enable/disable auto-close
+
+### **Setup Commands** (One-time)
+- `/channel_set #forum` - Add forum for tracking
+- `/log #logs` - Set log channel
+- `/admin_add @user` - Add initial admins
+
+### **Maintenance Commands**
+- `!sync` - Register slash commands (owner only)
+- `/send_review_ui` - Manually trigger review interface
+
+---
+
+## 🔍 **Troubleshooting Commands**
+
+**Commands not appearing?**
+- Use `!sync` and wait up to 1 hour
+
+**Auto-close not working?**
+- Check `/settings` → Auto-Close Settings
+- Use `/auto_close_toggle true` to enable
+
+**User can't access admin commands?**
+- Add with `/admin_add @user` or `/admin_role_add @role`
+- Verify in `/admin_list`
+
+**Settings interface not responding?**
+- Ensure user has admin permissions
+- Check for JavaScript errors in browser console (web dashboard)
+
+---
+
+## 🎯 **Best Practices**
+
+1. **Use `/settings`** for most configuration changes - it's user-friendly and validates input
+2. **Set up logging early** with `/log #channel` to track all bot activity
+3. **Configure auto-close** based on your community needs (24 hours is good default)
+4. **Add role-based admins** with `/admin_role_add` for easier permission management
+5. **Check `/admin_list`** regularly to maintain proper admin access
+6. **Use `/leaderboard`** to showcase top community members
+7. **Monitor log channel** for any issues or unusual activity
+
+---
+
+*This documentation covers Discord Reputation Bot V3.1. For setup guides and additional information, see the main README.md and guides/ folder.*

--- a/README.md
+++ b/README.md
@@ -8,35 +8,39 @@
   <a href="https://github.com/Wk4021/Marketplace-Discord-Rep-Bot/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Wk4021/Marketplace-Discord-Rep-Bot?style=for-the-badge" alt="License"/></a>
 </p>
 
-# 🌟 Discord Reputation Bot V3.0-beta
+# 🌟 Discord Reputation Bot V3.1
 
-A **complete reputation system** for Discord marketplace communities featuring **star ratings**, **detailed reviews**, **integrated web dashboard**, and **professional moderation tools**. Transform your Discord server into a trusted marketplace with TOS gating, review management, comprehensive user analytics, and live Discord integration.
+A **complete reputation system** for Discord marketplace communities featuring **star ratings**, **detailed reviews**, **auto-close management**, **interactive settings**, and **integrated web dashboard**. Transform your Discord server into a trusted marketplace with intelligent thread management, comprehensive moderation tools, and live Discord integration.
 
-## 🆕 **What's New in V3.0-beta**
-- ⭐ **Star Rating System** (1-10 ratings with visual stars)
-- 📝 **Detailed Reviews** (text reviews with rating modal)
-- 🌐 **Integrated Web Dashboard** (real-time Discord widget integration)
-- 🎨 **Dark/Light Mode** (theme-aware interface with automatic Discord widget switching)
-- 🔗 **Thread Tracking** (direct links to Discord posts from reviews)
-- 👑 **Admin System** (force close posts, manage admins)
-- 📊 **Enhanced UI** (improved embeds and user experience)
-- 🔧 **Modular Architecture** (separated logging system)
+## 🆕 **What's New in V3.1**
+- 🕐 **Auto-Close System** (configurable thread closure after first review)
+- ⚙️ **Interactive Settings** (comprehensive `/settings` dashboard with modal forms)
+- 🔔 **Review Notifications** (users get mentioned when receiving reviews)
+- 🔘 **Cancel Controls** (thread owners can prevent auto-close for multiple items)
+- 🤖 **Background Tasks** (automated thread monitoring and closure)
+- 👑 **Enhanced Admin Tools** (role-based permissions, improved commands)
+- 📊 **Comprehensive Logging** (all actions logged to console and Discord)
+- 🛠️ **Better UX** (visual feedback, validation, error handling)
 
 ---
 
 ## 🚀 Features
 
-### 🔒 **TOS Gating & Thread Management**
+### 🔒 **TOS Gating & Intelligent Thread Management**
 - **Smart TOS Prompts**: New threads require Terms of Service acceptance
 - **Live Countdown**: Discord timestamps show exact timeout
 - **Message Protection**: Auto-delete messages before TOS acceptance
-- **Auto-Close**: Threads close automatically if unattended
-- **Admin Override**: Admins can force close any post
+- **Smart Auto-Close**: Threads close automatically after first review (V3.1)
+- **Cancel Controls**: Thread owners can prevent closure for multiple items (V3.1)
+- **Background Monitoring**: Automated task checks every 10 minutes (V3.1)
+- **Admin Override**: Admins can force close any post with comprehensive logging
 
 ### ⭐ **Advanced Review System**
 - **1-10 Star Ratings**: Detailed rating system with visual stars
 - **Review Modal**: Professional popup for collecting ratings and notes
 - **Review Notes**: Detailed text feedback (up to 500 characters)
+- **User Notifications**: Instant mentions when users receive reviews (V3.1)
+- **Auto-Close Triggers**: First review starts configurable countdown (V3.1)
 - **Latest Reviews**: Display recent reviews with full context
 - **Average Ratings**: Smart calculation with star visualization
 - **Review History**: Complete review timeline for users
@@ -52,12 +56,14 @@ A **complete reputation system** for Discord marketplace communities featuring *
 - **Real-time Data**: Live updates from Discord API and database
 - **Thread Integration**: Persistent Discord post links stored in database
 
-### 👑 **Admin System**
-- **Configurable Admins**: Add/remove admins via commands
+### 👑 **Enhanced Admin System**
+- **Interactive Settings**: Comprehensive `/settings` dashboard (V3.1)
+- **Role-Based Permissions**: Support for both user IDs and role IDs (V3.1)
+- **Auto-Close Management**: Toggle and configure auto-close system (V3.1)
+- **Configurable Admins**: Add/remove admins via commands or settings UI
 - **Force Close**: Override close restrictions for moderation
-- **Admin Commands**: `/admin_add`, `/admin_remove`, `/admin_list`
-- **Enhanced Logging**: Track admin actions and user activity
-- **Permission Checking**: Smart role-based permissions
+- **Enhanced Logging**: All actions logged to console and Discord channels (V3.1)
+- **Modal Interfaces**: User-friendly forms for all configuration changes (V3.1)
 
 ### 📊 **Analytics & Reporting**
 - **User Statistics**: Comprehensive user activity tracking
@@ -167,6 +173,13 @@ Discord-Reputation-Bot/
    admin_ids:              # Admin user IDs
      - 111222333444555666  # Your admin user ID
      - 777888999000111222  # Additional admin IDs
+   admin_role_ids:         # Admin role IDs (V3.1)
+     - 123456789012345678  # Staff role ID
+     - 987654321098765432  # Moderator role ID
+   
+   # Auto-Close Settings (V3.1)
+   auto_close_enabled: true   # Enable auto-close after first review
+   auto_close_hours: 24       # Hours before auto-close (1-168)
    
    # Web Dashboard Settings (Optional)
    server_name: "Your Server Name"
@@ -220,14 +233,24 @@ Discord-Reputation-Bot/
 
 ---
 
-## ⭐ New Review System
+## ⭐ Enhanced Review System (V3.1)
 
 ### **How It Works**
 1. **User clicks "⭐ Leave a Review"** button in Discord thread
 2. **Modal popup appears** requesting rating (1-10) and optional notes
 3. **Review is saved** to database with timestamp
-4. **UI updates** showing new average rating and latest reviews
-5. **Web dashboard** displays comprehensive review history
+4. **Thread owner gets mentioned** with review notification (V3.1)
+5. **First review triggers auto-close countdown** (configurable, V3.1)
+6. **Thread owner can cancel auto-close** for multiple items (V3.1)
+7. **UI updates** showing new average rating and latest reviews
+8. **Web dashboard** displays comprehensive review history
+
+### **Auto-Close Workflow (V3.1)**
+1. **First review received** → Auto-close timer starts (default: 24 hours)
+2. **Warning embed appears** with cancel button for multiple items
+3. **Thread owner can cancel** if they have multiple items to sell
+4. **Background task monitors** and closes expired threads automatically
+5. **All events logged** to console and Discord log channel
 
 ### **Star Display Examples**
 
@@ -242,15 +265,32 @@ Discord-Reputation-Bot/
 
 ### **Available Commands**
 
+#### **🔧 New V3.1 Commands**
+| Command | Description |
+|---------|-------------|
+| `/settings` | **Interactive settings dashboard** (admin only) |
+| `/auto_close_toggle [enabled]` | Enable/disable auto-close feature (admin only) |
+| `/auto_close_hours <hours>` | Set auto-close timer 1-168 hours (admin only) |
+| `/send_review_ui` | Manually send review interface (admin only) |
+
+#### **📊 Public Commands**
 | Command | Description |
 |---------|-------------|
 | `/reviews @user` | View user's rating and recent reviews |
 | `/leaderboard` | Top 10 highest rated users |
-| `/admin_add @user` | Add user as admin (admin only) |
-| `/admin_remove @user` | Remove admin privileges (admin only) |
-| `/admin_list` | View all current admins (admin only) |
+
+#### **👑 Admin Commands**
+| Command | Description |
+|---------|-------------|
+| `/admin_add @user` | Add user as admin |
+| `/admin_remove @user` | Remove admin privileges |
+| `/admin_list` | View all current admins |
+| `/admin_role_add @role` | Add admin role (V3.1) |
+| `/admin_role_remove @role` | Remove admin role (V3.1) |
 | `/channel_set #forum` | Enable reviews for forum channel |
 | `/log #channel` | Set log channel for review notifications |
+
+**💡 Tip**: Use `/settings` for easy configuration through interactive interface!
 
 ---
 
@@ -310,6 +350,18 @@ A: Check browser console for JavaScript errors and ensure widget iframe loads pr
 **Q: Slash commands not appearing?**
 A: Use `!sync` command and wait up to 1 hour for global registration
 
+**Q: Auto-close not working?**
+A: Check if auto-close is enabled in `/settings` or use `/auto_close_toggle true`
+
+**Q: How to configure auto-close timer?**
+A: Use `/settings` → Auto-Close Settings or `/auto_close_hours <1-168>`
+
+**Q: Thread closed too early?**
+A: Thread owners can cancel auto-close using the button that appears after first review
+
+**Q: Settings command not working?**
+A: Ensure you have admin permissions (user ID or role ID in config)
+
 **Q: How do I get Discord user IDs for admin config?**
 A: Enable Developer Mode in Discord, right-click user → Copy User ID
 
@@ -332,8 +384,8 @@ A: Enable Developer Mode in Discord, right-click user → Copy User ID
 ---
 
 <p align="center">
-  <strong>🌟 Discord Reputation Bot V3.0-beta 🌟</strong><br/>
-  <em>Transform your Discord server into a trusted marketplace</em>
+  <strong>🌟 Discord Reputation Bot V3.1 🌟</strong><br/>
+  <em>Transform your Discord server into a trusted marketplace with intelligent automation</em>
 </p>
 
 <p align="center">

--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -1,4 +1,4 @@
-# Discord Reputation Bot V3.0-beta Configuration
+# Discord Reputation Bot V3.1 Configuration
 # Copy this file to config.yaml and update with your server's information
 
 # ═══════════════════════════════════════════════════════════
@@ -45,6 +45,22 @@ tos_message: |
 # TOS Decline Response - Message shown when user declines TOS
 tos_decline_response: |
   Marketplace terms not accepted. Thread will now be closed.
+
+# ═══════════════════════════════════════════════════════════
+#                 AUTO-CLOSE SETTINGS (V3.1)
+# ═══════════════════════════════════════════════════════════
+
+# Auto-Close Feature - NEW in V3.1
+# Automatically closes marketplace threads after receiving the first review
+# to keep the server clean and prevent clutter from completed transactions
+auto_close_enabled: true  # Set to false to disable auto-close feature entirely
+auto_close_hours: 24      # Hours to wait before auto-closing (1-168 hours, default: 24)
+
+# How it works:
+# 1. When a thread receives its FIRST review, a 24-hour countdown begins
+# 2. Thread owner gets a warning message with a button to cancel if they have multiple items
+# 3. After 24 hours (or configured time), the thread automatically closes
+# 4. Admins can modify these settings using /settings or /auto_close_toggle commands
 
 # ═══════════════════════════════════════════════════════════
 #                  WEB DASHBOARD SETTINGS
@@ -112,6 +128,31 @@ webhook_secret: ""
 #   min_review_length: 10
 
 # ═══════════════════════════════════════════════════════════
+#                    V3.1 COMMAND REFERENCE
+# ═══════════════════════════════════════════════════════════
+
+# New Slash Commands in V3.1:
+# 
+# PUBLIC COMMANDS:
+# /reviews <user>          - Check a user's reviews and ratings
+# /leaderboard            - Show top 10 rated users
+# 
+# ADMIN COMMANDS:
+# /settings               - Interactive settings dashboard (RECOMMENDED)
+# /auto_close_toggle      - Enable/disable auto-close feature
+# /auto_close_hours       - Set auto-close timer (1-168 hours)
+# /send_review_ui         - Manually send review interface to thread
+# /channel_set <channel>  - Add forum channel for tracking
+# /log <channel>          - Set log channel
+# /admin_add <user>       - Add admin user
+# /admin_remove <user>    - Remove admin user
+# /admin_list             - List all admins
+# /admin_role_add <role>  - Add admin role
+# /admin_role_remove <role> - Remove admin role
+#
+# TIP: Use /settings for easy configuration through interactive interface!
+
+# ═══════════════════════════════════════════════════════════
 #                      SETUP CHECKLIST
 # ═══════════════════════════════════════════════════════════
 
@@ -124,12 +165,16 @@ webhook_secret: ""
 # ✅ 5. Added your user ID to admin_ids
 # ✅ 6. Updated the TOS channel reference in tos_message
 # ✅ 7. Set your server name and invite link
-# ✅ 8. Invited the bot to your server with proper permissions
+# ✅ 8. Configured auto-close settings (NEW in V3.1)
+# ✅ 9. Invited the bot to your server with proper permissions
+# ✅ 10. Run !sync command after starting bot to register slash commands
 # 
 # Required bot permissions:
 # - Send Messages, Embed Links, Use Slash Commands
 # - Manage Threads, View Channels, Read Message History
 # - Connect, Speak (if using voice features in the future)
+#
+# AFTER SETUP: Use /settings command for easy configuration!
 
 # ═══════════════════════════════════════════════════════════
 #                      SUPPORT & DOCS


### PR DESCRIPTION
Introduces a configurable auto-close feature for threads after the first review, including background tasks for automated closure, cancellation controls, and user notifications. Adds an interactive `/settings` dashboard with modal forms for managing auto-close, TOS, server, and admin settings. Updates documentation and configuration examples to reflect new commands and features. Enhances database schema and utilities to support auto-close scheduling and cancellation.